### PR TITLE
feature/dependency prefixes

### DIFF
--- a/autoeden/__init__.py
+++ b/autoeden/__init__.py
@@ -1,6 +1,6 @@
+import os
 import shutil
 from pathlib import Path
-import os
 
 from .file import File
 from .import_ import Import
@@ -11,16 +11,12 @@ from .package import Package
 
 def edenise(
         root_directory,
-        name,
-        eden_prefix,
-        eden_dependencies,
+        package,
         target_path=None,
         eden_path=None,
-        should_rename_modules=False,
-        should_remove_type_annotations=False
 ):
-    target_path = target_path or f"{os.getcwd()}/../build_target/{name}_eden"
-    eden_path = eden_path or f"{os.getcwd()}/../build_eden/{eden_prefix}"
+    target_path = target_path or f"{os.getcwd()}/../build_target/{package.name}_eden"
+    eden_path = eden_path or f"{os.getcwd()}/../build_eden/{package.prefix}"
 
     print(f"Creating {target_path}...")
     shutil.rmtree(
@@ -31,17 +27,6 @@ def edenise(
         root_directory,
         target_path,
         symlinks=True
-    )
-
-    target_path = Path(target_path)
-
-    package = Package(
-        target_path / name,
-        prefix=eden_prefix,
-        is_top_level=True,
-        eden_dependencies=eden_dependencies,
-        should_rename_modules=should_rename_modules,
-        should_remove_type_annotations=should_remove_type_annotations
     )
 
     eden_path = Path(eden_path)

--- a/autoeden/package.py
+++ b/autoeden/package.py
@@ -60,18 +60,20 @@ class Package(DirectoryItem):
         }
 
         name = config_dict["name"]
-        dependency_names = config_dict.get(
+        dependency_dicts = config_dict.get(
             "eden_dependencies", []
         )
+        config_dict["eden_dependencies"] = []
         dependencies = [
             Package.from_config(
-                config_dict,
+                {
+                    **config_dict,
+                    **dependency_dict,
+                },
                 is_top_level=False,
-                name=dependency_name,
-                eden_dependencies=[],
             )
-            for dependency_name
-            in dependency_names
+            for dependency_dict
+            in dependency_dicts
         ]
 
         path = Path(

--- a/autoeden/package.py
+++ b/autoeden/package.py
@@ -1,7 +1,7 @@
 import importlib
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Iterable
 
 from .file import File
 from .item import DirectoryItem, Member, Item
@@ -10,11 +10,11 @@ from .item import DirectoryItem, Member, Item
 class Package(DirectoryItem):
     def __init__(
             self,
-            path: Path,
+            name,
             prefix: str,
             is_top_level: bool,
             parent: Optional["Package"] = None,
-            eden_dependencies: Optional[List[str]] = None,
+            eden_dependencies: Iterable["Package"] = (),
             should_rename_modules: bool = False,
             should_remove_type_annotations: bool = False
     ):
@@ -41,27 +41,66 @@ class Package(DirectoryItem):
             prefix,
             parent=parent
         )
-        self._path = path
+        if isinstance(
+                name, str
+        ):
+            self._path = Path(
+                importlib.import_module(
+                    name
+                ).__file__
+            ).parent
+        else:
+            self._path = name
 
         self.is_top_level = is_top_level
-        self._eden_dependencies = [
-            Package(
-                Path(
-                    importlib.import_module(
-                        dependency
-                    ).__file__
-                ).parent,
-                prefix=prefix,
-                is_top_level=True,
-                should_rename_modules=should_rename_modules,
-                should_remove_type_annotations=should_remove_type_annotations,
-            )
-            for dependency in (
-                    eden_dependencies or []
-            )
-        ]
+        self._eden_dependencies = eden_dependencies
         self._should_rename_modules = should_rename_modules
         self._should_remove_type_annotations = should_remove_type_annotations
+
+    @classmethod
+    def from_config(
+            cls,
+            config_dict,
+            is_top_level=True,
+            **overrides,
+    ):
+        def parse_boolean(key):
+            return config_dict.get(
+                key, ""
+            ).lower().startswith("t")
+
+        config_dict = {
+            **config_dict,
+            **overrides,
+        }
+
+        name = config_dict["name"]
+        string = config_dict.get(
+            "eden_dependencies"
+        )
+        if string is not None:
+            dependency_names = string.split(",")
+        else:
+            dependency_names = []
+        dependencies = [
+            Package.from_config(
+                config_dict,
+                is_top_level=False,
+                name=dependency_name,
+                eden_dependencies=None,
+            )
+            for dependency_name
+            in dependency_names
+        ]
+
+        return Package(
+            name=name,
+            prefix=config_dict["eden_prefix"],
+            is_top_level=is_top_level,
+            eden_dependencies=dependencies,
+            should_rename_modules=parse_boolean("should_rename_modules"),
+            should_remove_type_annotations=parse_boolean("should_remove_type_annotations"),
+        )
 
     @property
     def name(self) -> str:
@@ -160,7 +199,7 @@ class Package(DirectoryItem):
         return self._should_remove_type_annotations
 
     @property
-    def eden_dependencies(self) -> List["Package"]:
+    def eden_dependencies(self) -> Iterable["Package"]:
         """
         Packages on which this project depends. e.g. autoconf
         """

--- a/scripts/edenise.py
+++ b/scripts/edenise.py
@@ -3,7 +3,8 @@
 from configparser import ConfigParser
 from sys import argv
 
-from autofit.tools import edenise
+from autoeden import Package
+from autoeden import edenise
 
 
 def main(
@@ -15,23 +16,15 @@ def main(
             f"{root_directory}/eden.ini"
         )
 
-        eden_dependencies = [
-            dependency.strip()
-            for dependency
-            in config.get(
-                "eden",
-                "eden_dependencies"
-            ).split(",")
-        ]
+        section = config["eden"]
 
-        edenise.edenise(
+        package = Package.from_config(
+            section
+        )
+
+        edenise(
             root_directory=root_directory,
-            name=config.get("eden", "name"),
-            prefix=config.get("eden", "prefix"),
-            eden_prefix=config.get("eden", "eden_prefix"),
-            eden_dependencies=eden_dependencies,
-            should_rename_modules=config.get("eden", "should_rename_modules").lower().startswith("t"),
-            should_remove_type_annotations=config.get("eden", "should_remove_type_annotations").lower().startswith("t"),
+            package=package,
         )
     except ValueError:
         print("Usage: ./edenise.py root_directory")

--- a/scripts/edenise.py
+++ b/scripts/edenise.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from configparser import ConfigParser
+from pathlib import Path
 from sys import argv
+
+import yaml
 
 from autoeden import Package
 from autoeden import edenise
@@ -11,15 +13,11 @@ def main(
         root_directory
 ):
     try:
-        config = ConfigParser()
-        config.read(
-            f"{root_directory}/eden.ini"
-        )
-
-        section = config["eden"]
+        with open(root_directory / "eden.yaml") as f:
+            config = yaml.safe_load(f)
 
         package = Package.from_config(
-            section
+            config
         )
 
         edenise(
@@ -33,5 +31,5 @@ def main(
 
 if __name__ == "__main__":
     main(
-        argv[1]
+        Path(argv[1])
     )

--- a/test_autoeden/conftest.py
+++ b/test_autoeden/conftest.py
@@ -1,3 +1,4 @@
+import importlib
 from pathlib import Path
 
 import pytest
@@ -15,19 +16,31 @@ package_directory = Path(
 def make_package():
     prefix = "VIS_CTI"
     autoconf = Package(
-        "autoconf",
+        Path(
+            importlib.import_module(
+                "autoconf"
+            ).__file__
+        ).parent,
         prefix=prefix,
         is_top_level=False,
         should_rename_modules=True,
     )
     autofit = Package(
-        "autofit",
+        Path(
+            importlib.import_module(
+                "autofit"
+            ).__file__
+        ).parent,
         prefix=prefix,
         is_top_level=False,
         should_rename_modules=True,
     )
     return Package(
-        "autoeden",
+        Path(
+            importlib.import_module(
+                "autoeden"
+            ).__file__
+        ).parent,
         prefix="VIS_CTI",
         is_top_level=True,
         eden_dependencies=[autoconf, autofit],

--- a/test_autoeden/conftest.py
+++ b/test_autoeden/conftest.py
@@ -13,11 +13,24 @@ package_directory = Path(
     name="package"
 )
 def make_package():
+    prefix = "VIS_CTI"
+    autoconf = Package(
+        "autoconf",
+        prefix=prefix,
+        is_top_level=False,
+        should_rename_modules=True,
+    )
+    autofit = Package(
+        "autofit",
+        prefix=prefix,
+        is_top_level=False,
+        should_rename_modules=True,
+    )
     return Package(
-        package_directory,
+        "autoeden",
         prefix="VIS_CTI",
         is_top_level=True,
-        eden_dependencies=["autoconf", "autofit"],
+        eden_dependencies=[autoconf, autofit],
         should_rename_modules=True
     )
 

--- a/test_autoeden/test_import.py
+++ b/test_autoeden/test_import.py
@@ -21,9 +21,9 @@ def make_import(file):
 @pytest.mark.parametrize(
     "source, target",
     [
-        ("import autofit.tools.edenise", "\nimport VIS_CTI_Autofit.VIS_CTI_Tools.VIS_CTI_Edenise\n"),
+        ("import autofit.tools.edenise", "\nimport VIS_CTI_Autofit.VIS_CTI_Tools.edenise\n"),
         ("import autofit", "\nimport VIS_CTI_Autofit\n"),
-        ("import autofit.tools.edenise.Line", "\nimport VIS_CTI_Autofit.VIS_CTI_Tools.VIS_CTI_Edenise.Line\n"),
+        ("import autofit.tools.edenise.Line", "\nimport VIS_CTI_Autofit.VIS_CTI_Tools.Line\n"),
     ]
 )
 def test_direct_import(

--- a/test_autoeden/test_package.py
+++ b/test_autoeden/test_package.py
@@ -14,9 +14,11 @@ autoeden_path = directory.parent / "autoeden"
 def make_package():
     return Package.from_config({
         'name': 'autoeden',
-        'prefix': 'prefix',
         'eden_prefix': 'eden_prefix',
-        'eden_dependencies': ['autoeden'],
+        'eden_dependencies': [{
+            "name": "autoeden",
+            'eden_prefix': 'dependency_prefix',
+        }],
         'should_rename_modules': False,
         'should_remove_type_annotations': False,
     })
@@ -24,8 +26,10 @@ def make_package():
 
 def test_parse(package):
     assert package.path == autoeden_path
+    assert package.prefix == "eden_prefix"
 
 
 def test_dependency(package):
     dependency, = package.eden_dependencies
     assert dependency.path == autoeden_path
+    assert dependency.prefix == "dependency_prefix"

--- a/test_autoeden/test_package.py
+++ b/test_autoeden/test_package.py
@@ -1,21 +1,31 @@
 from pathlib import Path
 
+import pytest
+
 from autoeden import Package
 
 directory = Path(__file__).parent
+autoeden_path = directory.parent / "autoeden"
 
 
-def test_parse():
-    package = Package.from_config({
+@pytest.fixture(
+    name="package"
+)
+def make_package():
+    return Package.from_config({
         'name': 'autoeden',
         'prefix': 'prefix',
         'eden_prefix': 'eden_prefix',
-        'eden_dependencies': 'autoeden',
-        'should_rename_modules': "false",
-        'should_remove_type_annotations': "false",
+        'eden_dependencies': ['autoeden'],
+        'should_rename_modules': False,
+        'should_remove_type_annotations': False,
     })
-    autoeden_path = directory.parent / "autoeden"
+
+
+def test_parse(package):
     assert package.path == autoeden_path
 
+
+def test_dependency(package):
     dependency, = package.eden_dependencies
     assert dependency.path == autoeden_path

--- a/test_autoeden/test_package.py
+++ b/test_autoeden/test_package.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from autoeden import Package
+
+directory = Path(__file__).parent
+
+
+def test_parse():
+    package = Package.from_config({
+        'name': 'autoeden',
+        'prefix': 'prefix',
+        'eden_prefix': 'eden_prefix',
+        'eden_dependencies': 'autoeden',
+        'should_rename_modules': "false",
+        'should_remove_type_annotations': "false",
+    })
+    autoeden_path = directory.parent / "autoeden"
+    assert package.path == autoeden_path
+
+    dependency, = package.eden_dependencies
+    assert dependency.path == autoeden_path


### PR DESCRIPTION
Eden now uses YAML instead of INI

Here's an example
```yaml
name: autofit
eden_prefix: VIS_CTI
eden_dependencies: 
  - name: autoconf
should_rename_modules: false
should_remove_type_annotation: true
```

Dependencies can now be configured independently, i.e. so that they can have their own prefix
```yaml
name: autofit
eden_prefix: VIS_CTI
eden_dependencies: 
  - name: autoconf
  - eden_prefix: EDEN_SUCKS
should_rename_modules: false
should_remove_type_annotation: true
```

Any fields not defined in the dependency's notation are inherited 
